### PR TITLE
ragged array class

### DIFF
--- a/healpix-geo-python/pyproject.toml
+++ b/healpix-geo-python/pyproject.toml
@@ -16,6 +16,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 geometries = ["shapely>=2"]
+ragged = ["ragged", "awkward"]
 
 [tool.maturin]
 module-name = "healpix_geo._healpix_geo_python"

--- a/healpix-geo-python/python/healpix_geo/__init__.py
+++ b/healpix-geo-python/python/healpix_geo/__init__.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import healpix_geo.ellipsoid  # noqa: F401
 from healpix_geo import _healpix_geo_python, geometry, nested, ring, zuniq
+from healpix_geo._healpix_geo_python import RaggedArray
 from healpix_geo.geometry import Bbox
 from healpix_geo.mesh import vertex_to_lonlat
 
@@ -102,6 +103,7 @@ __all__ = [
     "slices",
     "geometry",
     "Bbox",
+    "RaggedArray",
     "vertex_to_lonlat",
     "lonlat_to_cartesian",
     "cartesian_to_lonlat",

--- a/healpix-geo-python/python/healpix_geo/tests/test_ragged.py
+++ b/healpix-geo-python/python/healpix_geo/tests/test_ragged.py
@@ -66,3 +66,33 @@ def test_apply_elementwise(func, expected):
 
     np.testing.assert_allclose(actual.data, expected)
     assert actual.offsets is obj.offsets
+
+
+def test_as_awkward():
+    ak = pytest.importorskip("awkward")
+
+    offsets = np.array([0, 3, 4, 6], dtype="uint64")
+    data = np.linspace(0, 1, 7, dtype="float32")
+    obj = RaggedArray(offsets, data)
+
+    actual = obj.as_awkward()
+    expected = ak.Array(
+        [data[start:stop] for start, stop in zip(offsets[:-1], offsets[1:])]
+    )
+
+    assert ak.to_list(actual) == ak.to_list(expected)
+
+
+def test_as_ragged():
+    ragged = pytest.importorskip("ragged")
+
+    offsets = np.array([0, 3, 4, 6], dtype="uint64")
+    data = np.linspace(0, 1, 7, dtype="float32")
+    obj = RaggedArray(offsets, data)
+
+    actual = obj.as_ragged()
+    expected = ragged.array(
+        [data[start:stop] for start, stop in zip(offsets[:-1], offsets[1:])]
+    )
+
+    assert ragged.all(actual == expected)

--- a/healpix-geo-python/python/healpix_geo/tests/test_ragged.py
+++ b/healpix-geo-python/python/healpix_geo/tests/test_ragged.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+
+from healpix_geo import RaggedArray
+
+
+@pytest.mark.parametrize(
+    "offsets",
+    (
+        pytest.param(np.array([0, 3, 4, 6], dtype="int64"), id="int64"),
+        pytest.param(np.array([0, 3, 4, 6], dtype="uint64"), id="uint64"),
+        pytest.param(np.array([0, 3, 4, 6], dtype="int8"), id="int8"),
+    ),
+)
+def test_init(offsets):
+    data = np.linspace(0, 1, 7, dtype="float16")
+
+    obj = RaggedArray(offsets, data)
+
+    # ragged array is a container and thus must not copy for uint64
+    assert offsets.dtype != np.dtype("uint64") or obj.offsets is offsets
+    assert obj.data is data
+
+
+@pytest.mark.parametrize(
+    ["offsets", "message"],
+    (
+        pytest.param(
+            np.array([[0, 1], [2, 3]], dtype="int64"),
+            "offsets must be 1-dimensional",
+            id="2-d",
+        ),
+        pytest.param(
+            np.array([0.1, 0.2], dtype="float16"),
+            "offsets must be of integer dtype",
+            id="float",
+        ),
+    ),
+)
+def test_init_errors(offsets, message):
+    data = np.arange(5, dtype="int8")
+
+    with pytest.raises(ValueError, match=message):
+        RaggedArray(offsets, data)
+
+
+@pytest.mark.parametrize(
+    ["func", "expected"],
+    (
+        pytest.param(
+            lambda x: x * 10,
+            np.linspace(0, 10, 7, dtype="float32"),
+            id="scalar product",
+        ),
+        pytest.param(
+            lambda x: x + 1, np.linspace(1, 2, 7, dtype="float32"), id="scalar addition"
+        ),
+    ),
+)
+def test_apply_elementwise(func, expected):
+    offsets = np.array([0, 3, 4, 6], dtype="uint64")
+    data = np.linspace(0, 1, 7, dtype="float32")
+    obj = RaggedArray(offsets, data)
+
+    actual = obj.apply_elementwise(func)
+
+    np.testing.assert_allclose(actual.data, expected)
+    assert actual.offsets is obj.offsets

--- a/healpix-geo-python/python/healpix_geo/tests/test_ragged.py
+++ b/healpix-geo-python/python/healpix_geo/tests/test_ragged.py
@@ -20,6 +20,9 @@ def test_init(offsets):
     # ragged array is a container and thus must not copy for uint64
     assert offsets.dtype != np.dtype("uint64") or obj.offsets is offsets
     assert obj.data is data
+    assert obj.dtype == data.dtype
+    assert obj.shape == (3, 3)
+    assert obj.ndim == 2
 
 
 @pytest.mark.parametrize(

--- a/healpix-geo-python/src/lib.rs
+++ b/healpix-geo-python/src/lib.rs
@@ -9,6 +9,8 @@ mod mesh;
 mod topology;
 mod traits;
 
+mod ragged;
+
 #[pymodule]
 mod nested {
     #[pymodule_export]
@@ -78,4 +80,7 @@ mod healpix_geo {
 
     #[pymodule_export]
     use crate::ellipsoid::resolve_ellipsoid;
+
+    #[pymodule_export]
+    use crate::ragged::RaggedArray;
 }

--- a/healpix-geo-python/src/ragged.rs
+++ b/healpix-geo-python/src/ragged.rs
@@ -1,0 +1,92 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyFunction, PyModule};
+
+use numpy::{
+    PyArray1, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods, PyUntypedArray,
+    PyUntypedArrayMethods, dtype,
+};
+
+/// very basic implementation of a ragged array
+#[pyclass(frozen)]
+#[derive(Debug)]
+struct RaggedArray {
+    #[pyo3(get)]
+    cuts: Py<PyArray1<u64>>,
+    #[pyo3(get)]
+    data: Py<PyUntypedArray>,
+}
+
+#[pymethods]
+impl RaggedArray {
+    /// construct the ragged array from offsets and data
+    #[new]
+    fn create<'py>(
+        py: Python<'py>,
+        cuts: &Bound<'py, PyUntypedArray>,
+        data: &Bound<'py, PyUntypedArray>,
+    ) -> PyResult<Self> {
+        let cuts_dtype = cuts.dtype();
+        let cuts_ = (if cuts_dtype.is_equiv_to(&dtype::<u64>(py)) {
+            let array = cuts.cast::<PyArrayDyn<u64>>()?;
+
+            array.reshape([array.len()])
+        } else {
+            Err(PyValueError::new_err(format!(
+                "cuts must be of dtype uint64, got {cuts_dtype}"
+            )))
+        })?;
+
+        Ok(Self {
+            cuts: cuts_.unbind(),
+            data: data.clone().unbind(),
+        })
+    }
+
+    /// apply a element-wise function
+    fn apply_element_wise<'py>(
+        &self,
+        py: Python<'py>,
+        func: &Bound<'py, PyFunction>,
+    ) -> PyResult<Self> {
+        let result = func.call1((self.data.bind(py),))?;
+        let new_data = result.cast::<PyUntypedArray>()?;
+
+        Ok(Self {
+            cuts: self.cuts.clone_ref(py),
+            data: new_data.clone().unbind(),
+        })
+    }
+
+    /// convert to a awkward array
+    fn as_awkward<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let awkward = PyModule::import(py, "awkward")?;
+        let contents = awkward.getattr("contents")?;
+        let index = awkward.getattr("index")?;
+
+        let array_cls = awkward.getattr("Array")?;
+        let list_offset_array_cls = contents.getattr("ListOffsetArray")?;
+        let index64_cls = index.getattr("Index64")?;
+        let numpy_array_cls = contents.getattr("NumpyArray")?;
+
+        let offsets = self.cuts.bind(py);
+        let data = self.data.bind(py);
+
+        let layout = list_offset_array_cls.call1((
+            index64_cls.call1((offsets,))?,
+            numpy_array_cls.call1((data,))?,
+        ))?;
+
+        array_cls.call1((layout,))
+    }
+
+    /// convert to a ragged array
+    fn as_ragged<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let ragged = PyModule::import(py, "ragged")?;
+        let array_cls = ragged.getattr("array")?;
+
+        let awkward_array = self.as_awkward(py)?;
+
+        array_cls.call1((awkward_array,))
+    }
+}

--- a/healpix-geo-python/src/ragged.rs
+++ b/healpix-geo-python/src/ragged.rs
@@ -1,8 +1,10 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyFunction, PyModule, PyString};
+use pyo3::types::{PyFunction, PyModule, PyString, PyTuple};
 
-use numpy::{PyArray1, PyArrayDescrMethods, PyUntypedArray, PyUntypedArrayMethods, dtype};
+use numpy::{
+    PyArray1, PyArrayDescrMethods, PyArrayMethods, PyUntypedArray, PyUntypedArrayMethods, dtype,
+};
 
 /// very basic implementation of a ragged array
 #[pyclass(frozen)]
@@ -12,6 +14,8 @@ pub(crate) struct RaggedArray {
     offsets: Py<PyArray1<u64>>,
     #[pyo3(get)]
     data: Py<PyUntypedArray>,
+
+    shape: [usize; 2],
 }
 
 #[pymethods]
@@ -57,10 +61,38 @@ impl RaggedArray {
             )))
         })?;
 
+        let readonly_offsets = offsets_.readonly();
+
+        let array_shape = [
+            offsets_.len() - 1,
+            readonly_offsets
+                .as_slice()?
+                .windows(2)
+                .map(|window| window[1] - window[0])
+                .max()
+                .unwrap_or(0) as usize,
+        ];
+
         Ok(Self {
             offsets: offsets_.unbind(),
             data: data.clone().unbind(),
+            shape: array_shape,
         })
+    }
+
+    #[getter]
+    fn shape<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        PyTuple::new(py, self.shape)
+    }
+
+    #[getter]
+    fn dtype<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.data.bind(py).getattr("dtype")
+    }
+
+    #[getter]
+    fn ndim(&self) -> usize {
+        self.shape.len()
     }
 
     /// apply a element-wise function
@@ -75,6 +107,7 @@ impl RaggedArray {
         Ok(Self {
             offsets: self.offsets.clone_ref(py),
             data: new_data.clone().unbind(),
+            shape: self.shape,
         })
     }
 

--- a/healpix-geo-python/src/ragged.rs
+++ b/healpix-geo-python/src/ragged.rs
@@ -1,18 +1,15 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyFunction, PyModule};
+use pyo3::types::{PyFunction, PyModule, PyString};
 
-use numpy::{
-    PyArray1, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods, PyUntypedArray,
-    PyUntypedArrayMethods, dtype,
-};
+use numpy::{PyArray1, PyArrayDescrMethods, PyUntypedArray, PyUntypedArrayMethods, dtype};
 
 /// very basic implementation of a ragged array
 #[pyclass(frozen)]
 #[derive(Debug)]
-struct RaggedArray {
+pub(crate) struct RaggedArray {
     #[pyo3(get)]
-    cuts: Py<PyArray1<u64>>,
+    offsets: Py<PyArray1<u64>>,
     #[pyo3(get)]
     data: Py<PyUntypedArray>,
 }
@@ -23,28 +20,51 @@ impl RaggedArray {
     #[new]
     fn create<'py>(
         py: Python<'py>,
-        cuts: &Bound<'py, PyUntypedArray>,
+        offsets: &Bound<'py, PyUntypedArray>,
         data: &Bound<'py, PyUntypedArray>,
     ) -> PyResult<Self> {
-        let cuts_dtype = cuts.dtype();
-        let cuts_ = (if cuts_dtype.is_equiv_to(&dtype::<u64>(py)) {
-            let array = cuts.cast::<PyArrayDyn<u64>>()?;
+        let numpy = PyModule::import(py, "numpy")?;
+        let isdtype = numpy.getattr("isdtype")?;
+        let integer_category = PyString::new(py, "integral");
 
-            array.reshape([array.len()])
+        let py_dtype = offsets.getattr("dtype")?;
+        let rs_dtype = offsets.dtype();
+
+        let shape = offsets.shape();
+        if shape.len() != 1 {
+            Err(PyValueError::new_err(format!(
+                "offsets must be 1-dimensional, got shape {:?}",
+                shape
+            )))?;
+        }
+
+        let offsets_ = (if isdtype
+            .call1((py_dtype, integer_category))?
+            .extract::<bool>()?
+        {
+            if !rs_dtype.is_equiv_to(&dtype::<u64>(py)) {
+                let array = numpy
+                    .getattr("astype")?
+                    .call1((offsets, numpy.getattr("uint64")?))?;
+
+                Ok(array.cast::<PyArray1<u64>>()?.clone())
+            } else {
+                Ok(offsets.cast::<PyArray1<u64>>()?.clone())
+            }
         } else {
             Err(PyValueError::new_err(format!(
-                "cuts must be of dtype uint64, got {cuts_dtype}"
+                "offsets must be of integer dtype, got {rs_dtype}"
             )))
         })?;
 
         Ok(Self {
-            cuts: cuts_.unbind(),
+            offsets: offsets_.unbind(),
             data: data.clone().unbind(),
         })
     }
 
     /// apply a element-wise function
-    fn apply_element_wise<'py>(
+    fn apply_elementwise<'py>(
         &self,
         py: Python<'py>,
         func: &Bound<'py, PyFunction>,
@@ -53,7 +73,7 @@ impl RaggedArray {
         let new_data = result.cast::<PyUntypedArray>()?;
 
         Ok(Self {
-            cuts: self.cuts.clone_ref(py),
+            offsets: self.offsets.clone_ref(py),
             data: new_data.clone().unbind(),
         })
     }
@@ -69,7 +89,7 @@ impl RaggedArray {
         let index64_cls = index.getattr("Index64")?;
         let numpy_array_cls = contents.getattr("NumpyArray")?;
 
-        let offsets = self.cuts.bind(py);
+        let offsets = self.offsets.bind(py);
         let data = self.data.bind(py);
 
         let layout = list_offset_array_cls.call1((

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,5 +1,3 @@
-# clear cache
-
 [workspace]
 channels = ["conda-forge"]
 name = "healpix-geo"

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,6 +36,8 @@ pytest = "*"
 pytest-cov = "*"
 shapely = "*"
 cdshealpix = "*"
+awkward = ">=2.13.0"
+ragged = ">=0.3.0"
 
 [feature.tests.tasks]
 tests = { cmd = "pytest --cov=healpix_geo", cwd = "healpix-geo-python", default-environment = "dev" }


### PR DESCRIPTION
Some functions like `*uniq.zoom_to` or vectorized coverage functions (e.g. #252) can return variable-sized output. This adds a very simple container class that allows returning ragged arrays to python, and from there either extract the components or convert to a more elaborate ragged array library like [`ragged`](https://github.com/scikit-hep/ragged) or [`awkward`](https://github.com/scikit-hep/awkward).