### PR TITLE
resolve the build failures

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -123,7 +123,9 @@ jobs:
           frozen: true
 
       - name: editable install
-        run: pixi install --frozen -e "$ENV"
+        run: |
+          pixi clean --build
+          pixi install --frozen -e "$ENV"
 
       - name: Check imports
         run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -180,7 +180,9 @@ jobs:
           frozen: true
 
       - name: editable install
-        run: pixi install --frozen -e "$ENV"
+        run: |
+          pixi clean --build
+          pixi install --frozen -e "$ENV"
 
       - name: Check imports
         run: |


### PR DESCRIPTION
This is currently just forcing a rebuild.

It would be nice to know why the change in directory (moving from `python/healpix-geo` to `healpix-geo-python`) caused pixi to fail.