### PR TITLE
avoid tree-shaking for js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "healpix-geo-wasm"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "cdshealpix 0.9.1 (git+https://github.com/cds-astro/cds-healpix-rust.git?rev=d9d017cda85a097b65d200e3c4cccefc54665915)",
  "console_error_panic_hook",

--- a/healpix-geo-js/package.json
+++ b/healpix-geo-js/package.json
@@ -1,6 +1,5 @@
 {
   "name": "healpix-geo",
-  "version": "0.2.0",
   "license": "Apache-2.0",
   "author": "Justus Magin <keewis@posteo.de>",
   "repository": "https://github.com/GRID4EARTH/healpix-geo",

--- a/healpix-geo-js/scripts/build.sh
+++ b/healpix-geo-js/scripts/build.sh
@@ -58,14 +58,14 @@ target="$1"
 
 [ -d pkg ] && rm -rf pkg
 
-opts=("--out-name" "index" "--target" "$target" "--out-dir" "$root")
+opts=("--out-name" "healpix-geo" "--target" "$target" "--out-dir" "$root")
 if [[ "$mode" == "dev" ]]; then
    opts+=("--dev")
 fi
 
 wasm-pack build "${opts[@]}"
 
-jq '.name = "healpix-geo" | .repository.url = "git+https://github.com/GRID4EARTH/healpix-geo.git" | .["sideEffects"] = []' \
+jq '.name = "healpix-geo" | .repository.url = "git+https://github.com/GRID4EARTH/healpix-geo.git" | .sideEffects = true' \
     pkg/package.json \
     > pkg/package.json.new
 mv pkg/package.json.new pkg/package.json

--- a/healpix-geo-js/scripts/build.sh
+++ b/healpix-geo-js/scripts/build.sh
@@ -58,7 +58,7 @@ target="$1"
 
 [ -d pkg ] && rm -rf pkg
 
-opts=("--out-name" "healpix-geo" "--target" "$target" "--out-dir" "$root")
+opts=("--out-name" "index" "--target" "$target" "--out-dir" "$root")
 if [[ "$mode" == "dev" ]]; then
    opts+=("--dev")
 fi

--- a/healpix-geo-js/scripts/build.sh
+++ b/healpix-geo-js/scripts/build.sh
@@ -58,7 +58,7 @@ target="$1"
 
 [ -d pkg ] && rm -rf pkg
 
-opts=("--out-name" "index" "--target" "$target" "--out-dir" "$root")
+opts=("--out-name" "healpix_geo" "--target" "$target" "--out-dir" "$root")
 if [[ "$mode" == "dev" ]]; then
    opts+=("--dev")
 fi

--- a/healpix-geo-js/tests/bulk.test.ts
+++ b/healpix-geo-js/tests/bulk.test.ts
@@ -1,5 +1,5 @@
-import init, * as healpixGeo from "../pkg/index.js";
-import { Grid } from "../pkg/index.js";
+import init, * as healpixGeo from "../pkg/healpix_geo.js";
+import { Grid } from "../pkg/healpix_geo.js";
 import { describe, expect, test } from "vitest";
 
 const wgs84 = {

--- a/healpix-geo-js/tests/ellipsoid.test.ts
+++ b/healpix-geo-js/tests/ellipsoid.test.ts
@@ -1,5 +1,5 @@
-import init, * as healpixGeo from "../pkg/index.js";
-import { Ellipsoid } from "../pkg/index.js";
+import init, * as healpixGeo from "../pkg/healpix_geo.js";
+import { Ellipsoid } from "../pkg/healpix_geo.js";
 import { describe, expect, test } from "vitest";
 
 describe("Ellipsoid.from", () => {

--- a/healpix-geo-js/tests/grid.test.ts
+++ b/healpix-geo-js/tests/grid.test.ts
@@ -1,5 +1,5 @@
-import init, * as healpixGeo from "../pkg/index.js";
-import { Coordinate, Ellipsoid, Grid } from "../pkg/index.js";
+import init, * as healpixGeo from "../pkg/healpix_geo.js";
+import { Coordinate, Ellipsoid, Grid } from "../pkg/healpix_geo.js";
 import { describe, expect, test } from "vitest";
 
 const wgs84 = {

--- a/healpix-geo-js/tests/nested.test.ts
+++ b/healpix-geo-js/tests/nested.test.ts
@@ -1,5 +1,5 @@
-import init, * as healpixGeo from "../pkg/index.js";
-import { Coordinate, Ellipsoid } from "../pkg/index.js";
+import init, * as healpixGeo from "../pkg/healpix_geo.js";
+import { Coordinate, Ellipsoid } from "../pkg/healpix_geo.js";
 import { describe, expect, test } from "vitest";
 
 describe("nested bitcombine", () => {

--- a/healpix-geo-js/tests/ring.test.ts
+++ b/healpix-geo-js/tests/ring.test.ts
@@ -1,5 +1,5 @@
-import init, * as healpixGeo from "../pkg/index.js";
-import { Coordinate, Ellipsoid } from "../pkg/index.js";
+import init, * as healpixGeo from "../pkg/healpix_geo.js";
+import { Coordinate, Ellipsoid } from "../pkg/healpix_geo.js";
 import { describe, expect, test } from "vitest";
 
 describe("ring bitcombine", () => {

--- a/healpix-geo-js/tests/types.test-d.ts
+++ b/healpix-geo-js/tests/types.test-d.ts
@@ -1,5 +1,5 @@
-import type { EllipsoidInput, GridOptions } from "../pkg/index.js";
-import { Ellipsoid, Grid } from "../pkg/index.js";
+import type { EllipsoidInput, GridOptions } from "../pkg/healpix_geo.js";
+import { Ellipsoid, Grid } from "../pkg/healpix_geo.js";
 import { describe, expectTypeOf, test } from "vitest";
 
 // The generated `.d.ts` is the API surface TypeScript consumers actually see.

--- a/healpix-geo-js/tests/zuniq.test.ts
+++ b/healpix-geo-js/tests/zuniq.test.ts
@@ -1,5 +1,5 @@
-import init, * as healpixGeo from "../pkg/index.js";
-import { Coordinate, Ellipsoid } from "../pkg/index.js";
+import init, * as healpixGeo from "../pkg/healpix_geo.js";
+import { Coordinate, Ellipsoid } from "../pkg/healpix_geo.js";
 import { describe, expect, test } from "vitest";
 
 describe("zuniq bitcombine", () => {


### PR DESCRIPTION
Looks like the package metadata was not configured to avoid tree-shaking the webassembly files.