### PR TITLE
support compacting cell ids

### DIFF
--- a/healpix-geo-python/python/healpix_geo/tests/test_index.py
+++ b/healpix-geo-python/python/healpix_geo/tests/test_index.py
@@ -301,6 +301,83 @@ class TestRangeMOCIndex:
         np.testing.assert_equal(actual, expected)
 
     @pytest.mark.parametrize(
+        ["level", "cell_ids", "expected"],
+        (
+            pytest.param(
+                2,
+                np.arange(12 * 4**2, dtype="uint64"),
+                # all base cells
+                np.array(
+                    [
+                        288230376151711744,
+                        864691128455135232,
+                        1441151880758558720,
+                        2017612633061982208,
+                        2594073385365405696,
+                        3170534137668829184,
+                        3746994889972252672,
+                        4323455642275676160,
+                        4899916394579099648,
+                        5476377146882523136,
+                        6052837899185946624,
+                        6629298651489370112,
+                    ],
+                    dtype="uint64",
+                ),
+                id="full_domain",
+            ),
+            # base cells 1, 2, 5, 6
+            pytest.param(
+                1,
+                np.concat(
+                    [
+                        np.arange(1 * 4**1, 3 * 4**1, dtype="uint64"),
+                        np.arange(5 * 4**1, 7 * 4**1, dtype="uint64"),
+                    ]
+                ),
+                np.array(
+                    [
+                        864691128455135232,
+                        1441151880758558720,
+                        3170534137668829184,
+                        3746994889972252672,
+                    ],
+                    dtype="uint64",
+                ),
+                id="ranges_with_gap",
+            ),
+            # one compacted cell
+            pytest.param(
+                3,
+                np.array([4, 5, 6, 7, 9, 15, 16, 19], dtype="uint64"),
+                (
+                    np.array(
+                        [
+                            54043195528445952,
+                            85568392920039424,
+                            139611588448485376,
+                            148618787703226368,
+                            175640385467449344,
+                        ],
+                        dtype="uint64",
+                    )
+                ),
+                id="isolated_pixels",
+            ),
+        ),
+    )
+    def test_compacted_cell_ids(
+        self,
+        level: int,
+        cell_ids: npt.NDArray[np.uint64],
+        expected: npt.NDArray[np.uint64],
+    ) -> None:
+        index = healpix_geo.nested.RangeMOCIndex.from_cell_ids(level, cell_ids)
+
+        actual = index.compacted_cell_ids()
+        np.testing.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize(
         ["level", "cell_ids"],
         (
             pytest.param(0, np.arange(12, dtype="uint64"), id="base cells"),

--- a/healpix-geo-python/src/index.rs
+++ b/healpix-geo-python/src/index.rs
@@ -17,6 +17,7 @@ use healpix_geo::index::{
     Array, CellRegion, ConcreteSlice, LabelIndexer, PositionalIndexer, Slice,
 };
 use healpix_geo::index::{GeometryQuery, Indexing, SetOperations};
+use healpix_geo::scalar::nested;
 
 trait IntoPySlice {
     fn into_pyslice<'py>(self, py: Python<'py>) -> Bound<'py, PySlice>;
@@ -495,6 +496,26 @@ impl RangeMOCIndex {
         });
 
         PyArray1::from_vec(py, ranges).reshape(shape)
+    }
+
+    /// Retrieve the compacted cell ids
+    ///
+    /// For now, the cell ids will always be in the ``zuniq`` scheme.
+    ///
+    /// Returns
+    /// -------
+    /// compacted: numpy.ndarray
+    ///     The compacted cell ids as array of dtype ``uint64``.
+    fn compacted_cell_ids<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<u64>>> {
+        let compacted: Vec<u64> = py.detach(move || {
+            self.region
+                .compacted_cell_ids()
+                .into_iter()
+                .map(|(hash, depth)| nested::conversion::to_zuniq(&hash, &depth))
+                .collect()
+        });
+
+        Ok(PyArray1::from_vec(py, compacted))
     }
 
     /// Subset the index using positions

--- a/healpix-geo/src/index/region.rs
+++ b/healpix-geo/src/index/region.rs
@@ -11,7 +11,8 @@ use moc::deser::json::from_json_aladin;
 use moc::moc::cell::CellMOC;
 use moc::moc::range::{CellSelection, RangeMOC};
 use moc::moc::{
-    CellMOCIntoIterator, CellMOCIterator, HasMaxDepth, RangeMOCIntoIterator, RangeMOCIterator,
+    CellMOCIntoIterator, CellMOCIterator, HasMaxDepth, IntoBMOC, RangeMOCIntoIterator,
+    RangeMOCIterator,
 };
 use moc::qty::{Hpx, MocQty};
 use num_traits::PrimInt;
@@ -131,6 +132,17 @@ impl CellRegion {
 
     pub fn ranges(&self) -> Vec<Range<u64>> {
         self.moc.moc_ranges().iter().cloned().collect()
+    }
+
+    pub fn compacted_cell_ids(&self) -> Vec<(u64, u8)> {
+        self.moc
+            .clone()
+            .into_range_moc_iter()
+            .cells()
+            .into_bmoc()
+            .into_iter()
+            .map(|c| (c.hash, c.depth))
+            .collect()
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {


### PR DESCRIPTION
By going through the `BMOC` data structure, we can convert the ranges of the index to compacted cell ids.

In the future I would like `healpix_geo::{scheme}::compact` functions that can support this outside the index.